### PR TITLE
Properly pass cli reporter option to mocha

### DIFF
--- a/bin/mocha-chrome
+++ b/bin/mocha-chrome
@@ -57,7 +57,7 @@ if (!/^(file|http(s?)):\/\//.test(file)) {
 }
 
 const mochaDefaults = {
-  reporter: 'spec',
+  reporter: flags.reporter || 'spec',
   useColors: !flags.colors
 };
 const mocha = deepAssign(mochaDefaults, JSON.parse(flags.mocha || '{}'));


### PR DESCRIPTION
<!-- Please place an x in all [ ] that apply -->

- [X] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

The CLI-interface is not currently tested using test suite. Manual testing with or w/o `--reporter` option was was done.

### Motivation / Use-Case

When using the `--reporter` flag from command line when calling `mocha-chrome`, the reporter value is not passed to `MochaChrome` and defaults to `spec`. This prevents using other reporters from CLI, such as `xunit`.

### Breaking Changes

No breaking changes.

### Additional Info
