### PR TITLE
Introduce flag to suppress resource loading errors (--ignore-resource-errors)

### DIFF
--- a/bin/mocha-chrome
+++ b/bin/mocha-chrome
@@ -13,11 +13,12 @@ const cli = meow(chalk`{underline Usage}
 
 
 {underline Options}
-  --mocha      A JSON string representing a config object to pass to Mocha
-  --log-level  Specify a log level; trace, debug, info, warn, error
-  --no-colors  Disable colors in Mocha's output
-  --reporter   Specify the Mocha reporter to use
-  --timeout    Specify the test startup timeout to use
+  --mocha                     A JSON string representing a config object to pass to Mocha
+  --log-level                 Specify a log level; trace, debug, info, warn, error
+  --no-colors                 Disable colors in Mocha's output
+  --reporter                  Specify the Mocha reporter to use
+  --timeout                   Specify the test startup timeout to use
+  --ignore-resource-errors    Suppress resource error logging
 
 
 {underline Examples}
@@ -62,7 +63,8 @@ const mochaDefaults = {
 };
 const mocha = deepAssign(mochaDefaults, JSON.parse(flags.mocha || '{}'));
 const logLevel = flags.logLevel || 'error';
-const options = { url, logLevel, mocha };
+const ignoreResourceErrors = flags.ignoreResourceErrors || false
+const options = { url, logLevel, mocha, ignoreResourceErrors };
 const runner = new MochaChrome(options);
 
 runner.on('ended', stats => {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class MochaChrome {
       chromeFlags: [],
       loadTimeout: 1000,
       logLevel: 'error',
+      ignoreResourceErrors: false,
       mocha: {
         reporter: 'spec',
         ui: 'bdd',
@@ -97,7 +98,7 @@ class MochaChrome {
     this.bus.watch(DOMStorage);
 
     chromeOut(log, Runtime);
-    network(this.bus, log, Network);
+    network(this.bus, log, Network, this.options.ignoreResourceErrors);
 
     this.client = client;
     this.instance = instance;

--- a/lib/network.js
+++ b/lib/network.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function network (bus, log, Network) {
+module.exports = function network (bus, log, Network, ignoreResourceErrors) {
 
   const requests = {};
   let mochaReceived = false;
@@ -21,7 +21,9 @@ module.exports = function network (bus, log, Network) {
     const request = requests[info.requestId];
     const { url, method } = request;
     const data = { url, method, reason: info.errorText };
-    log.error('Resource Failed to Load:', data);
+    if (!ignoreResourceErrors) {
+      log.error('Resource Failed to Load:', data);
+    }
     bus.emit('resourceFailed', data);
   });
 


### PR DESCRIPTION
<!-- Please place an x in all [ ] that apply -->

- [ ] This is a **bugfix**
- [X] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

This change affects only logging output - no tests added (yet).

### Motivation / Use-Case

This pull request introduces option from `mocha-phantomjs` that suppresses logging of resource errors via `--ignore-resource-errors` option. By default, resource errors are logged.

This change only affects the console logging - resource error events are still emitted to bus (if `MochaChrome` is used programmatically, the users can choose whether to suppress or log the events themselves).

See relevant `mocha-phantomjs` discussion [here](https://github.com/nathanboktae/mocha-phantomjs/pull/169)

### Breaking Changes

No breaking changes.

### Additional Info
