### PR TITLE
Ignore empty newValue since it causes SyntaxError: Unexpected end of …

### DIFF
--- a/lib/event-bus.js
+++ b/lib/event-bus.js
@@ -16,6 +16,10 @@ module.exports = class EventBus {
         return;
       }
 
+      if (newValue === '') {
+        return;
+      }
+
       const evnt = JSON.parse(newValue);
 
       this.log.info('⇢ EventBus', evnt);


### PR DESCRIPTION
…JSON input

<!-- Please place an x in all [ ] that apply -->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No

### Motivation / Use-Case

I noticed that occasionally headless Chrome sends in the start phase an empty `newValue`. This causes `JSON.parse(newValue)` to fail with following error (linenumbers are slightly off due to debug logging):

```
Chrome Instance launched
CDP Client Connected
Data { storageId:
   { securityOrigin: 'http://localhost:9990',
     isLocalStorage: true },
  key: 'bus',
  oldValue: '',
  newValue: '{"name":"width","data":""}' }
⇢ EventBus { name: 'width', data: '' }
Data { storageId:
   { securityOrigin: 'http://localhost:9990',
     isLocalStorage: true },
  key: 'bus',
  oldValue: '{"name":"width","data":""}',
  newValue: '' }
undefined:1



SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Chrome.DOMStorage.domStorageItemUpdated.data (/Users/hsalokor/src/github/mocha-chrome/lib/event-bus.js:21:25)
```

This is a simple fix that ignores the empty value, and prevents the `SyntaxError` from JSON parsing. Since the value is empty, it is not sent to bus.

### Breaking Changes

No breaking changes.

### Additional Info

This is relatively hard to reproduce at least on Mac desktop, but seems to occur almost always on our Linux-based test environment.