### PR TITLE
Add --chrome-flags, --ignore-exceptions and --ignore-console flags

### DIFF
--- a/bin/mocha-chrome
+++ b/bin/mocha-chrome
@@ -18,13 +18,17 @@ const cli = meow(chalk`{underline Usage}
   --no-colors                 Disable colors in Mocha's output
   --reporter                  Specify the Mocha reporter to use
   --timeout                   Specify the test startup timeout to use
+  --ignore-exceptions         Suppress exceptions logging
+  --ignore-console            Suppress console logging
   --ignore-resource-errors    Suppress resource error logging
+  --chrome-flags              A JSON string representing an array of flags to pass to Chrome
 
 
 {underline Examples}
   $ mocha-chrome test.html --no-colors
   $ mocha-chrome test.html --reporter dot
   $ mocha-chrome test.html --mocha '\{"ui":"tdd"\}'
+  $ mocha-chrome test.html --chrome-flags '["--some-flag", "--and-another-one"]'
 `);
 
 if (!cli.input.length && !Object.getOwnPropertyNames(cli.flags).length) {
@@ -62,9 +66,16 @@ const mochaDefaults = {
   useColors: !flags.colors
 };
 const mocha = deepAssign(mochaDefaults, JSON.parse(flags.mocha || '{}'));
-const logLevel = flags.logLevel || 'error';
-const ignoreResourceErrors = flags.ignoreResourceErrors || false
-const options = { url, logLevel, mocha, ignoreResourceErrors };
+const chromeFlags = JSON.parse(flags.chromeFlags || '[]');
+const options = {
+  url,
+  mocha,
+  chromeFlags,
+  logLevel: flags.logLevel,
+  ignoreExceptions: flags.ignoreExceptions,
+  ignoreConsole: flags.ignoreConsole,
+  ignoreResourceErrors: flags.ignoreResourceErrors,
+};
 const runner = new MochaChrome(options);
 
 runner.on('ended', stats => {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ class MochaChrome {
       chromeFlags: [],
       loadTimeout: 1000,
       logLevel: 'error',
+      ignoreExceptions: false,
+      ignoreConsole: false,
       ignoreResourceErrors: false,
       mocha: {
         reporter: 'spec',
@@ -97,7 +99,7 @@ class MochaChrome {
 
     this.bus.watch(DOMStorage);
 
-    chromeOut(log, Runtime);
+    chromeOut(log, this.options, Runtime);
     network(this.bus, log, Network, this.options.ignoreResourceErrors);
 
     this.client = client;

--- a/lib/chrome-out.js
+++ b/lib/chrome-out.js
@@ -5,13 +5,18 @@ const unmirror = require('chrome-unmirror');
 /*
  * Pipes chrome console messages to stdout
  */
-module.exports = function chromeOut (log, Runtime) {
-
+module.exports = function chromeOut (log, options, Runtime) {
   Runtime.exceptionThrown((exception) => {
-    log.error('[chrome-exception]', exception);
+    if (!options.ignoreExceptions) {
+      log.error('[chrome-exception]', exception);
+    }
   });
 
   Runtime.consoleAPICalled(({type, args}) => {
+    if (options.ignoreConsole) {
+      return;
+    }
+
     if (type === 'warning') {
       type = 'warn';
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "bdd": "mocha test/test.js --timeout 10000",
-    "lint": "eslint index.js test/*.js",
+    "lint": "eslint index.js test/*.js lib/*.js",
     "test": "npm run lint && npm run bdd"
   },
   "bin": {


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [X] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

The CLI-interface is not currently tested using test suite. Manual testing was performed.

### Motivation / Use-Case

When performing tests using iframes, you need to pass a `--disable-web-security` flag to the Chrome itself, or it will throw cross-origin exceptions. I didn't want to set it as default though.

As for `ignore` flags, I often test code that requires to explicitly throw plenty of errors and it pollutes my test results a lot. It'd be nice if I could mute them.

### Breaking Changes

None.