### PR TITLE
listen to both DOMStorage items being added and updated so users may use localStorage.clear()

### DIFF
--- a/client/event-bus.js
+++ b/client/event-bus.js
@@ -1,15 +1,11 @@
 (function (root) {
   'use strict';
 
-  // set the storage item so any subsequent calls to .setItem will trigger
-  // the DOMStorage.domStorageItemUpdated event in lib/event-bus.js
-  window.localStorage.setItem('bus', '');
-
   root._eventbus = {
     emit (name, data = '') {
       let json = JSON.stringify({ name, data });
 
-      window.localStorage.setItem('bus', json);
+      window.localStorage.setItem('mocha-chrome-bus', json);
     }
   };
 

--- a/lib/event-bus.js
+++ b/lib/event-bus.js
@@ -10,22 +10,21 @@ module.exports = class EventBus {
     log.info('EventBus initialized');
   }
 
+  handleDOMStorageChange ({ key, newValue }) {
+    if (key !== 'mocha-chrome-bus') {
+      return;
+    }
+
+    const evnt = JSON.parse(newValue);
+
+    this.log.info('⇢ EventBus', evnt);
+
+    this.bus.emit(evnt.name, evnt.data);
+  }
+
   watch (DOMStorage) {
-    DOMStorage.domStorageItemUpdated(({ storageId, key, newValue }) => {
-      if (key !== 'bus') {
-        return;
-      }
-
-      if (newValue === '') {
-        return;
-      }
-
-      const evnt = JSON.parse(newValue);
-
-      this.log.info('⇢ EventBus', evnt);
-
-      this.bus.emit(evnt.name, evnt.data);
-    });
+    DOMStorage.domStorageItemUpdated(this.handleDOMStorageChange.bind(this));
+    DOMStorage.domStorageItemAdded(this.handleDOMStorageChange.bind(this));
   }
 
   emit (eventName, data) {

--- a/test/api.js
+++ b/test/api.js
@@ -99,4 +99,11 @@ describe('MochaChrome', () => {
     });
   });
 
+  it('supports test using and clearing localStorage', () => {
+    return test({ file: 'local-storage' }).then(({passes, failures}) => {
+      expect(passes).to.equal(2);
+      expect(failures).to.equal(1);
+    });
+  });
+
 });

--- a/test/html/local-storage.html
+++ b/test/html/local-storage.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <title>Test</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../node_modules/mocha/mocha.css" />
+    <script src="../../node_modules/mocha/mocha.js"></script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script>
+      mocha.ui('bdd');
+
+      describe('Tests using localStorage', function() {
+        afterEach(function() {
+          localStorage.clear();
+        });
+        it('can set an item', function() {
+          localStorage.setItem('foo', 'bar');
+        });
+        it('fails after setting an item', function() {
+          localStorage.setItem('baz', 'quz');
+          throw new Error('oh no!');
+        })
+        it('can set an item named bus', function() {
+          localStorage.setItem('bus', '{');
+        });
+      });
+
+      mocha.run();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION

> Thank you for submitting a pull request! Please note that this template is not
optional. Please fill out **_all_** fields, or your pull request may be rejected.
Please do not delete this template. Please do remove this header to acknowledge this message.

<!-- Please place an x in all [ ] that apply -->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Of course

### Motivation / Use-Case

`mocha-chrome` was hanging because I use `localStorage.clear()` in an `afterEach`, and causing `domStorageItemAdded` to fire instead of `domStorageItemUpdated`. The fix is to simply listen to both.

### Breaking Changes

None. I actually improved this area as I also changed the storage key to `mocha-chrome-bus` rather than `bus` so it is less likely to conflict with users keys.

### Additional Info
