### PR TITLE
use `sudo: required` due to travis upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ node_js:
   - 7
   - 8
 
-dist: trusty # Chrome needs Ubuntu Trusty
-
+sudo: required
 addons:
   chrome: stable
 


### PR DESCRIPTION
Travis has upgraded from trusty -> xenial to address Meltdown. There are
issues with Chrome in Xenial that can currently be worked around with
`sudo: required`.
At some point this workaround may be removable.
See https://github.com/travis-ci/travis-ci/issues/8836

<!-- Please place an x in all [ ] that apply -->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No new tests needed, this fixes the Travis build infrastructure.

However, for a sample breaking build without this change: https://travis-ci.org/smalls/mocha-chrome/builds/326961711

And with this change: https://travis-ci.org/smalls/mocha-chrome/builds/327001070

### Motivation / Use-Case

Travis has updated from Trusty to Xenial which is causing issues. This is their current recommended workaround; once they have a long-term fix, this change can be removed.

https://github.com/travis-ci/travis-ci/issues/8836 for more information.

### Breaking Changes

All current mocha-chrome & travis users may need to make similar changes in their `.travis.yml` files.

### Additional Info
