### PR TITLE
fix typo in cli help and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ users may choose to use the `--old-and-busted` flag, because your version is not
 the new hotness - it's old and busted;
 
 ```console
---old-and-busted            Take pity upon users of old-node. This option will run moche-chrome
+--old-and-busted            Take pity upon users of old-node. This option will run mocha-chrome
                             under Node < 8 using babel-register. Use at your own risk, and
                             without support.
 ```
@@ -93,7 +93,7 @@ $ mocha-chrome --help
     --log-level                 Specify a log level; trace, debug, info, warn, error
     --mocha                     A JSON string representing a config object to pass to Mocha
     --no-colors                 Disable colors in Mocha's output
-    --old-and-busted            Take pity upon users of old-node. This option will run moche-chrome
+    --old-and-busted            Take pity upon users of old-node. This option will run mocha-chrome
                                 under Node < 8 using babel-register. Use at your own risk, and
                                 without support.
     --reporter                  Specify the Mocha reporter to use

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,7 +20,7 @@ const cli = meow(chalk`{underline Usage}
   --log-level                 Specify a log level; trace, debug, info, warn, error
   --mocha                     A JSON string representing a config object to pass to Mocha
   --no-colors                 Disable colors in Mocha's output
-  --old-and-busted            Take pity upon users of old-node. This option will run moche-chrome
+  --old-and-busted            Take pity upon users of old-node. This option will run mocha-chrome
                               under Node < 8 using babel-register. Use at your own risk, and
                               without support.
   --reporter                  Specify the Mocha reporter to use


### PR DESCRIPTION

- [ ] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [x] This is a **typo fix**
- [ ] This is a **metadata update**

### Additional Info

Fix typo present in an explanation on the cli options. Fix also on README.md where present.
