### PR TITLE
Patch support for check mark (resolve #18)

### DIFF
--- a/lib/chrome-out.js
+++ b/lib/chrome-out.js
@@ -40,7 +40,11 @@ module.exports = function chromeOut (log, options, Runtime) {
 
     for (let arg of args) {
       if (arg.type === 'string') {
-        data.push(arg.value);
+        if ('win32' == process.platform) {
+          data.push(arg.value.replace("âœ“", '\u221A'));
+        } else {
+          data.push(arg.value.replace("âœ“", '\u2713'))
+        }
       }
       else {
         data.push(unmirror(arg));


### PR DESCRIPTION
As tested, the current mocha and mocha-chrome libraries output garbled output for passing unit tests, resulting in `âœ“` instead of a check mark.  

I assume the issue is probably related to content-encoding. Something is not being treated as UTF-8. 

In the meantime, this patch resolves the most common issue (the broken checkmark), in a way that (based on Mocha's source code) should print a compatible character (check mark on Linux/macOS, square root on Windows).

Thank you :smile:

> Thank you for submitting a pull request! Please note that this template is not
optional. Please fill out **_all_** fields, or your pull request may be rejected.
Please do not delete this template. Please do remove this header to acknowledge this message.

<!-- Please place an x in all [ ] that apply -->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  Please explain the **motivation** or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
