### PR TITLE
Patch unicode symbols (resolve #18)

### DIFF
--- a/lib/chrome-out.js
+++ b/lib/chrome-out.js
@@ -40,7 +40,15 @@ module.exports = function chromeOut (log, options, Runtime) {
 
     for (let arg of args) {
       if (arg.type === 'string') {
-        data.push(arg.value);
+        let value = arg.value;
+        if ('win32' == process.platform) {
+          value = value.replace("âœ“", '\u221A');
+          value = value.replace("✓", '\u221A');
+        }
+        else {
+          value = value.replace("âœ“", '\u2713');
+        }
+        data.push(value);
       }
       else {
         data.push(unmirror(arg));


### PR DESCRIPTION
<!-- Please place an x in all [ ] that apply -->

- [X] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

As tested, the current mocha and mocha-chrome libraries output garbled output for passing unit tests, resulting in `âœ“` instead of a check mark.  

I assume the issue is probably related to content-encoding. Something is not being treated as UTF-8. 

In the meantime, this patch resolves the most common issue (the broken checkmark), in a way that (based on Mocha's source code) should print a compatible character (check mark on Linux/macOS, square root on Windows).

Thank you :smile:

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
