### PR TITLE
chore: migrate from deep-assign to lodash merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const deepAssign = require('deep-assign');
+const mergeOptions = require('merge-options');
 
 const log = require('loglevel');
 const unmirror = require('chrome-unmirror');
@@ -18,7 +18,7 @@ process.on('unhandledRejection', (error) => {
 class MochaChrome {
   constructor(options) {
     // eslint-disable-next-line no-param-reassign
-    options = deepAssign(
+    options = mergeOptions(
       {
         chromeFlags: [],
         loadTimeout: 1000,

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "chrome-remote-interface": "^0.27.0",
     "chrome-unmirror": "^0.1.0",
     "debug": "^4.1.1",
-    "deep-assign": "^3.0.0",
     "import-local": "^2.0.0",
     "loglevel": "^1.4.1",
     "meow": "^5.0.0",
+    "merge-options": "^1.0.1",
     "nanobus": "^4.2.0"
   },
   "devDependencies": {

--- a/test/api.js
+++ b/test/api.js
@@ -1,7 +1,7 @@
 /* eslint-disable func-names, no-param-reassign, no-console */
 const path = require('path');
 
-const deepAssign = require('deep-assign');
+const mergeOptions = require('merge-options');
 const chai = require('chai');
 
 const MochaChrome = require('../index');
@@ -11,7 +11,7 @@ const { expect } = chai;
 function test(options) {
   const url = `file://${path.join(__dirname, '/html', `${options.file}.html`)}`;
 
-  options = deepAssign(
+  options = mergeOptions(
     (options = {
       url,
       mocha: { useColors: false },


### PR DESCRIPTION
<!-- Please place an x in all [ ] that apply -->

- [ ] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Not applicable, but the existing suite of tests passed with this change.

### Motivation / Use-Case

`deep-assign` has been deprecated by its original owner and it refers existing users to migrate to either [`lodash.merge`](https://lodash.com/docs/#merge) or [`merge-options`](https://github.com/schnittstabil/merge-options) when the package is installed through npm. This same warning message also appears for anyone installing `mocha-chrome`.

Both packages serve as adequate substitutions, but I went with Lodash. I imported `lodash.merge` directly to avoid inflating the package size. I can also easily change this PR to use `merge-options` if you would prefer that package.

### Breaking Changes

No breaking changes.

### Additional Info

Per your CONTRIBUTING file, `package-lock.json` was not included in this PR, though naturally its composition will be affected by the `package.json` change. I ensured that the existing test successfully passed by running `npm test`. I also attempted to mimic your commit message style, but I can change the commit message if you desire something different.

Thank you for providing a good substitute for phantomjs.