### PR TITLE
Add ability to use --no-colors CLI option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,7 +8,8 @@ const meow = require('meow');
 
 const MochaChrome = require('../');
 
-const cli = meow(chalk`{underline Usage}
+const cli = meow(
+  chalk`{underline Usage}
   $ mocha-chrome <file.html> [options]
 
 
@@ -31,15 +32,16 @@ const cli = meow(chalk`{underline Usage}
   $ mocha-chrome test.html --mocha '\{"ui":"tdd"\}'
   $ mocha-chrome test.html --chrome-flags '["--some-flag", "--and-another-one"]'
 `,
-{
-  flags: {
-    color: {
-      type: 'boolean',
-      alias: 'colors',
-      default: true
+  {
+    flags: {
+      color: {
+        type: 'boolean',
+        alias: 'colors',
+        default: true
+      }
     }
   }
-});
+);
 
 if (
   !cli.input.length &&

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,7 +19,7 @@ const cli = meow(chalk`{underline Usage}
   --ignore-resource-errors    Suppress resource error logging
   --log-level                 Specify a log level; trace, debug, info, warn, error
   --mocha                     A JSON string representing a config object to pass to Mocha
-  --no-colors                 Disable colors in Mocha's output
+  --no-color, --no-colors     Disable colors in Mocha's output
   --reporter                  Specify the Mocha reporter to use
   --timeout                   Specify the test startup timeout to use
   --version
@@ -30,7 +30,16 @@ const cli = meow(chalk`{underline Usage}
   $ mocha-chrome test.html --reporter dot
   $ mocha-chrome test.html --mocha '\{"ui":"tdd"\}'
   $ mocha-chrome test.html --chrome-flags '["--some-flag", "--and-another-one"]'
-`);
+`,
+{
+  flags: {
+    color: {
+      type: 'boolean',
+      alias: 'colors',
+      default: true
+    }
+  }
+});
 
 if (
   !cli.input.length &&
@@ -67,7 +76,7 @@ if (!/^(file|http(s?)):\/\//.test(file)) {
   url = `file://${fs.realpathSync(file)}`;
 }
 
-const useColors = !flags.colors;
+const useColors = flags.color;
 const reporter = flags.reporter || 'spec';
 const mocha = Object.assign(JSON.parse(flags.mocha || '{}'), { useColors, reporter });
 const chromeFlags = JSON.parse(flags.chromeFlags || '[]');


### PR DESCRIPTION
<!-- Please place an x in all [ ] that apply -->

- [ x ] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No.

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  Please explain the **motivation** or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

Option `--no-colors` doesn't work in current version. When the option is specified mocha's output is colorified.
I've fixed the problem.

### Breaking Changes

No.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

Added ability to use `--no-color` instead of `--no-colors`.