### PR TITLE
Replace useColors -> colors

### DIFF
--- a/client/shim.js
+++ b/client/shim.js
@@ -12,7 +12,7 @@
       mochaOptions = mochaOptions || {
         ui: 'bdd',
         reporter: 'spec',
-        useColors: true
+        colors: true
       };
 
       mocha.setup(mochaOptions);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class MochaChrome {
         mocha: {
           reporter: 'spec',
           ui: 'bdd',
-          useColors: true
+          colors: true
         }
       },
       options

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -68,9 +68,9 @@ if (!/^(file|http(s?)):\/\//.test(file)) {
   url = `file://${fs.realpathSync(file)}`;
 }
 
-const useColors = !!flags.colors;
+const colors = !!flags.colors;
 const reporter = flags.reporter || 'spec';
-const mocha = Object.assign(JSON.parse(flags.mocha || '{}'), { useColors, reporter });
+const mocha = Object.assign(JSON.parse(flags.mocha || '{}'), { colors, reporter });
 const chromeFlags = JSON.parse(flags.chromeFlags || '[]');
 const {
   chromeLauncher = {},

--- a/test/api.js
+++ b/test/api.js
@@ -14,7 +14,7 @@ function test(options) {
   options = deepAssign(
     (options = {
       url,
-      mocha: { useColors: false },
+      mocha: { colors: false },
       ignoreConsole: true,
       ignoreExceptions: true,
       ignoreResourceErrors: true


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Uses option `colors` instead of `useColors` with mocha, removing a deprecation warning issued when running tests with mocha-chrome in other projects (screenshot below shows an example).

![Screenshot with deprecation warning being shown at the top](https://user-images.githubusercontent.com/42754063/76226679-f814ff80-61fc-11ea-85e4-f53f21127eb4.png)