### PR TITLE
Fix mocha option from colors -> color

### DIFF
--- a/client/shim.js
+++ b/client/shim.js
@@ -12,7 +12,7 @@
       mochaOptions = mochaOptions || {
         ui: 'bdd',
         reporter: 'spec',
-        colors: true
+        color: true
       };
 
       mocha.setup(mochaOptions);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class MochaChrome {
         mocha: {
           reporter: 'spec',
           ui: 'bdd',
-          colors: true
+          color: true
         }
       },
       options

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -68,9 +68,9 @@ if (!/^(file|http(s?)):\/\//.test(file)) {
   url = `file://${fs.realpathSync(file)}`;
 }
 
-const colors = !!flags.colors;
+const color = !!flags.color;
 const reporter = flags.reporter || 'spec';
-const mocha = Object.assign(JSON.parse(flags.mocha || '{}'), { colors, reporter });
+const mocha = Object.assign(JSON.parse(flags.mocha || '{}'), { color, reporter });
 const chromeFlags = JSON.parse(flags.chromeFlags || '[]');
 const {
   chromeLauncher = {},

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "LICENSE",
     "README.md"
   ],
+  "peerDependencies": {
+    "mocha": ">= 7.0.0"
+  },
   "dependencies": {
     "chalk": "^2.0.1",
     "chrome-launcher": "^0.13.4",

--- a/test/api.js
+++ b/test/api.js
@@ -14,7 +14,7 @@ function test(options) {
   options = deepAssign(
     (options = {
       url,
-      mocha: { colors: false },
+      mocha: { color: false },
       ignoreConsole: true,
       ignoreExceptions: true,
       ignoreResourceErrors: true


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [x] yes
- [ ] no

Mocha v7 deprecates `useColors` in favor of `color`, and Mocha v8 and onwards don't support `useColors`. That means this fix of https://github.com/shellscape/mocha-chrome/pull/42#issuecomment-754027598 will work with Mocha v7 and forward, but not Mocha v6 and before.

### Please Describe Your Changes

Addresses https://github.com/shellscape/mocha-chrome/pull/42#issuecomment-754027598 to fix the updated mocha option from `colors` (wrong) to `color`.

This adds a `peerDependencies` entry in `package.json` for `"mocha": ">= 7.0.0"` to represent the requirement of a `mocha` version that supports the `color` option.